### PR TITLE
Lifesteal Global Reset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,14 +63,28 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+	<repository>
+		<id>il_totore</id>
+		<url>https://raw.githubusercontent.com/Iltotore/maven/master/</url>
+	</repository>
+	<repository>
+	<id>codemc-repo</id>
+	<url>https://repo.codemc.org/repository/maven-public/</url>
+	<layout>default</layout>
+	</repository>
     </repositories>
 
-    <dependencies>
+   <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+		<dependency>
+		  <groupId>de.tr7zw</groupId>
+		  <artifactId>item-nbt-api-plugin</artifactId>
+		  <version>2.9.0-SNAPSHOT</version>
+		</dependency>
     </dependencies>
 </project>

--- a/src/main/java/me/sirhenry/lifesteal/LifeSteal.java
+++ b/src/main/java/me/sirhenry/lifesteal/LifeSteal.java
@@ -26,6 +26,7 @@ public final class LifeSteal extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerInteractListener(), this);
         getCommand("withdraw").setExecutor(new WithdrawCommand());
+        getCommand("smpreset").setExecutor(new ResetCommand());
         getConfig().options().copyDefaults(true);
         saveDefaultConfig();
         Bukkit.addRecipe(heartRecipe());

--- a/src/main/java/me/sirhenry/lifesteal/ResetCommand.java
+++ b/src/main/java/me/sirhenry/lifesteal/ResetCommand.java
@@ -1,0 +1,59 @@
+package me.sirhenry.lifesteal;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import de.tr7zw.nbtapi.*;
+import java.io.File;
+import java.io.IOException;
+
+public class ResetCommand implements CommandExecutor {
+	Plugin plugin = LifeSteal.getPlugin(LifeSteal.class);
+	
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) 
+	{	
+		Player me = ((Player) sender);
+		if(!me.isOp()) {
+			return false;
+		}
+		
+		for(OfflinePlayer player : Bukkit.getServer().getOfflinePlayers()){
+			String path = Bukkit.getWorldContainer() + File.separator + "lifesteal" + File.separator + "playerdata" + File.separator;
+			String f = player.getUniqueId() + ".dat";
+			NBTFile nbt;
+			
+			if(player.isOnline()) {
+				Player onlinePlayer = (Player) player;
+				onlinePlayer.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(plugin.getConfig().getDouble("DefaultHealth"));
+				continue;
+			}
+
+			try {
+				nbt = new NBTFile(new File(path + f));
+				NBTCompoundList list = nbt.getCompoundList("Attributes");
+				for(int i=0;i<list.size();i++) {
+					NBTListCompound item = list.get(i);
+					if(item.getString("Name").equals("minecraft:generic.max_health")) {
+						sender.sendMessage(item.getString("Base"));
+						item.setDouble("Base", plugin.getConfig().getDouble("DefaultHealth"));
+						nbt.save();
+						break;
+					} else {
+						continue;
+					}
+				}
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+		Bukkit.broadcastMessage("Season " + args[0] + ": '" + ChatColor.RED + ChatColor.BOLD + args[1] + ChatColor.RESET + "' has begun!");
+		return true;
+	}
+}


### PR DESCRIPTION
Sets everyone's hearts back to the configured default. captures offline players too.

Requires nbt-api and this only works on 1.18.

Server Administrators will have to add this plugin to their plugin folder additionally.